### PR TITLE
Fixed grid on default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,11 +4,7 @@
 <body>
 {% include navbar.html %}
 <div class="container m-t-2">
-    <div class="row">
-        <div class="col-md-12">
-            {{ content }}
-        </div>
-    </div>
+    {{ content }}
 </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-</div>
+<div class="row">
 {% for post in site.posts %}
 <div class="col-md-6 col-sm-12">
     <a href="{{ site.baseurl }}{{ post.url }}">
@@ -22,3 +22,4 @@ layout: default
     </a>
 </div>
 {% endfor %}
+</div>


### PR DESCRIPTION
- A row/col pair is not needed when the columns are 12. Instead content
can be directly inside of container.
- Index.html was missing row div around post column divs.